### PR TITLE
fix: fix the inverted rect display

### DIFF
--- a/src/shape/interval/color.ts
+++ b/src/shape/interval/color.ts
@@ -63,12 +63,18 @@ export function rect(
     // Deal with width or height is negative.
     const absX = width > 0 ? x : x + width;
     const absY = height > 0 ? y : y + height;
+
+    // the diff between height and minHeight
+    const heightDiff = minHeight - height;
+    // when data is 0, minHeight get actions.
+  
+    const isMinHeight = heightDiff > 0 && height === 0 ? true : false;
     const absWidth = Math.abs(width);
-    const absHeight = Math.abs(height);
+    const absHeight = Math.abs(isMinHeight ? minHeight : height);
     const finalX = absX + insetLeft;
-    const finalY = absY + insetTop;
+    const finalY = isMinHeight ? absY + insetTop - heightDiff : absY + insetTop;
     const finalWidth = absWidth - (insetLeft + insetRight);
-    const finalHeight = absHeight - (insetTop + insetBottom) || minHeight;
+    const finalHeight = absHeight - (insetTop + insetBottom);
 
     const clampWidth = tpShape
       ? finalWidth


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/antvis/g2/blob/master/CONTRIBUTING.md
-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] benchmarks are included
- [ ] commit message follows commit guidelines
- [ ] documents are updated

##### Description of change
* 修复了默认情况下，minHeight矩阵反向展示的效果。
* 原代码中，只设置了`height`的缺省高度为`minHeight`，原代码中的坐标`y`是根据实际数值计算而来的，`minHeight`并没有被包含其中，若没有重新计算坐标`y`，这样就会导致以原数值的y坐标为起点向下延伸，所以便导致了反向展示的bug。 

<!-- Provide a description of the change below this comment. -->
![3106527781](https://github.com/iamzone/G2/assets/48038769/8e3578f7-0b00-4b8b-85b3-c075d3261ba3)
![2464533322](https://github.com/iamzone/G2/assets/48038769/578df04e-1a9e-4c37-943b-56e9d86284c2)

